### PR TITLE
[macOS bugfix] Escaped dollar sign of OSTYPE call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,5 @@ TARGET = /usr/local/bin/ihsec
 install: bash
 
 bash:
-	if [[ "$OSTYPE" == "darwin"* ]]; then cp ihsec.sh ${TARGET}; chmod 755 ${TARGET}; else install -D -m 755 ihsec.sh ${TARGET}; fi
+	if [[ "$$OSTYPE" == "darwin"* ]]; then cp ihsec.sh ${TARGET}; chmod 755 ${TARGET}; else install -D -m 755 ihsec.sh ${TARGET}; fi
 


### PR DESCRIPTION
According to this https://stackoverflow.com/questions/2382764/escaping-in-makefile you need TWO dollar signs to escape the dollar sign. This fixes the problem in macOS while running 'sudo make' from the instructions.

*NOT* tested on Linux or anything other than macOS 10.14.4 (a.k.a Mojave). 

This should address the issue raised in #5.